### PR TITLE
Remove default FREEGLUT_LIB_PRAGMAS

### DIFF
--- a/freeglut/freeglut/include/GL/freeglut_std.h
+++ b/freeglut/freeglut/include/GL/freeglut_std.h
@@ -47,11 +47,7 @@
  * The default behavior depends on the compiler/platform.
  */
 #   ifndef FREEGLUT_LIB_PRAGMAS
-#       if ( defined(_MSC_VER) || defined(__WATCOMC__) ) && !defined(_WIN32_WCE)
-#           define FREEGLUT_LIB_PRAGMAS 1
-#       else
-#           define FREEGLUT_LIB_PRAGMAS 0
-#       endif
+#       define FREEGLUT_LIB_PRAGMAS 0
 #   endif
 
 #  ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Why are you linking the library from the header file?
I lost two hours not understanding why my program wants to link a library with a different name than it was built.
Can you delete this option by default?