### PR TITLE
Change GLUT_CURSOR_INFO from IDC_HELP to IDC_HAND

### DIFF
--- a/freeglut/freeglut/src/mswin/fg_cursor_mswin.c
+++ b/freeglut/freeglut/src/mswin/fg_cursor_mswin.c
@@ -72,7 +72,7 @@ void fgPlatformSetCursor ( SFG_Window *window, int cursorID )
     {
         MAP_CURSOR( GLUT_CURSOR_RIGHT_ARROW,         IDC_ARROW     );
         MAP_CURSOR( GLUT_CURSOR_LEFT_ARROW,          IDC_ARROW     ); /* XXX ToDo */
-        MAP_CURSOR( GLUT_CURSOR_INFO,                IDC_HELP      );
+        MAP_CURSOR( GLUT_CURSOR_INFO,                IDC_HAND      );
         MAP_CURSOR( GLUT_CURSOR_DESTROY,             IDC_CROSS     );
         MAP_CURSOR( GLUT_CURSOR_HELP,                IDC_HELP      );
         MAP_CURSOR( GLUT_CURSOR_CYCLE,               IDC_SIZEALL   );


### PR DESCRIPTION
This is a very simple fix. According to https://www.opengl.org/resources/libraries/glut/spec3/node28.html, `GLUT_CURSOR_INFO` should be a "Pointing Hand". `IDC_HELP` is however an arrow with a question mark; `IDC_HAND` gives the cursor image I am expecting.

Is there a reason for  `GLUT_CURSOR_INFO` being set to `IDC_HELP` (wich is also correctly used for ` GLUT_CURSOR_HELP`)?