### PR TITLE
Fix illegal instruction in glutTimerFuncUcall()

### DIFF
--- a/freeglut/freeglut/src/fg_callbacks.c
+++ b/freeglut/freeglut/src/fg_callbacks.c
@@ -74,7 +74,7 @@ void FGAPIENTRY glutTimerFuncUcall( unsigned int timeOut, FGCBTimerUC callback, 
             break;
     }
 
-    fgListInsert( &fgState.Timers, &node->Node, &timer->Node );
+    fgListInsert( &fgState.Timers, node ? &node->Node : NULL, &timer->Node );
 }
 
 IMPLEMENT_CALLBACK_FUNC_CB_ARG1(Timer, Timer)


### PR DESCRIPTION
When fgState.Timers.First is NULL, it goes straight to the fgListInsert() call
and tries to dereference &node->Node, with node being NULL, which is illegal.

I do not know how it was working before because searching for "Timers" on
the whole repository does not indicate any other place where fgState.Timers
is assigned anything but NULL, so the first call to glutTimerFuncUcall() should
have been an issue. Maybe compilers or runtime checks changed recently.
Did I miss something?