### PR TITLE
Do not link to libm on Windows

### DIFF
--- a/freeglut/freeglut/CMakeLists.txt
+++ b/freeglut/freeglut/CMakeLists.txt
@@ -581,7 +581,7 @@ ADD_DEMO(timer_callback  progs/demos/timer_callback/timer.c)
 # pkg-config support, to install at $(libdir)/pkgconfig
 # Define static build dependencies
 IF(WIN32)
-  SET(PC_LIBS_PRIVATE "-lopengl32 -lwinmm -lgdi32 -lm")
+  SET(PC_LIBS_PRIVATE "-lopengl32 -lwinmm -lgdi32")
 ELSEIF(FREEGLUT_GLES)
   IF(ANDROID)
     SET(PC_LIBS_PRIVATE "-llog -landroid -lGLESv2 -lGLESv1_CM -lEGL -lm")


### PR DESCRIPTION
According to my test, tryng to link `libm` on Windows (at least MSVC) will result in the error:
~~~
"C:\src\robotology-superbuild\build\src\ICUB\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\src\robotology-superbuild\build\src\ICUB\src\tools\iCubGui\src\iCubGui.vcxproj" (default target) (53) ->
(Link target) ->
  LINK : fatal error LNK1181: cannot open input file 'm.lib' [C:\src\robotology-superbuild\build\src\ICUB\src\tools\iCubGui\src\iCubGui.vcxproj]

    6 Warning(s)
    1 Error(s)
~~~