### PR TITLE
Fix 'suggest explicit braces' warning

### DIFF
--- a/src/mswin/fg_main_mswin.c
+++ b/src/mswin/fg_main_mswin.c
@@ -721,16 +721,22 @@ static LRESULT fghWindowProcKeyPress(SFG_Window *window, UINT uMsg, GLboolean ke
 #endif
 
     if( keypress != -1 )
+    {
         if (keydown)
+        {
             INVOKE_WCB( *window, Special,
                         ( keypress,
                             window->State.MouseX, window->State.MouseY )
             );
+        }
         else
+        {
             INVOKE_WCB( *window, SpecialUp,
                         ( keypress,
                             window->State.MouseX, window->State.MouseY )
             );
+        }
+    }
 
     fgState.Modifiers = INVALID_MODIFIERS;
 


### PR DESCRIPTION
On MSYS2 gcc:
```txt
C:/Users/katahiromz/Desktop/freeglut/src/mswin/fg_main_mswin.c: In function 'fghWindowProcKeyPress':
C:/Users/katahiromz/Desktop/freeglut/src/mswin/fg_main_mswin.c:723:7: warning: suggest explicit braces to avoid ambiguous 'else' [-Wdangling-else]
  723 |     if( keypress != -1 )
      |       ^
```