### PR TITLE
Fix aliasing violation

### DIFF
--- a/include/GL/freeglut_std.h
+++ b/include/GL/freeglut_std.h
@@ -227,15 +227,18 @@
     /*
      * I don't really know if it's a good idea... But here it goes:
      */
-    extern void* glutStrokeRoman;
-    extern void* glutStrokeMonoRoman;
-    extern void* glutBitmap9By15;
-    extern void* glutBitmap8By13;
-    extern void* glutBitmapTimesRoman10;
-    extern void* glutBitmapTimesRoman24;
-    extern void* glutBitmapHelvetica10;
-    extern void* glutBitmapHelvetica12;
-    extern void* glutBitmapHelvetica18;
+
+    struct freeglutStrokeFont;
+    struct freeglutBitmapFont;
+    extern struct freeglutStrokeFont glutStrokeRoman;
+    extern struct freeglutStrokeFont glutStrokeMonoRoman;
+    extern struct freeglutBitmapFont glutBitmap9By15;
+    extern struct freeglutBitmapFont glutBitmap8By13;
+    extern struct freeglutBitmapFont glutBitmapTimesRoman10;
+    extern struct freeglutBitmapFont glutBitmapTimesRoman24;
+    extern struct freeglutBitmapFont glutBitmapHelvetica10;
+    extern struct freeglutBitmapFont glutBitmapHelvetica12;
+    extern struct freeglutBitmapFont glutBitmapHelvetica18;
 
     /*
      * Those pointers will be used by following definitions:


### PR DESCRIPTION
Noticed when compiling with link-time optimizations.

````
include/GL/freeglut_std.h:240:18: error: type of ‘glutBitmapHelvetica18’ does not match original declaration [-Werror=lto-type-mismatch]
  240 |     extern void* glutBitmapHelvetica18;
      |                  ^
src/x11/fg_glutfont_definitions_x11.c:103:27: note: ‘glutBitmapHelvetica18’ was previously declared here
  103 | struct freeglutBitmapFont glutBitmapHelvetica18 ;
      |                           ^
src/x11/fg_glutfont_definitions_x11.c:103:27: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
````