### PR TITLE
Added FREEGLUT_BUILDING_LIB for GCC 11.3.0

### DIFF
--- a/src/gles_stubs.c
+++ b/src/gles_stubs.c
@@ -1,5 +1,6 @@
 /* TODO: implement me! */
 
+#define FREEGLUT_BUILDING_LIB
 #include <GL/freeglut.h>
 #include "fg_internal.h"
 


### PR DESCRIPTION
```
In file included from c:\gcc1130\x86_64-w64-mingw32\include\gl\freeglut_ext.h:287,
                 from c:\gcc1130\x86_64-w64-mingw32\include\gl\freeglut.h:18,
                 from gles_stubs.c:4:
gles_stubs.c:22:16: error: redefinition of 'glutCreateMenuUcall_ATEXIT_HACK'
   22 | int FGAPIENTRY glutCreateMenuUcall( FGCBMenuUC callback, FGCBUserData userData ) { return 0; }
      |                ^~~~~~~~~~~~~~~~~~~
c:\gcc1130\x86_64-w64-mingw32\include\gl\freeglut_ucall.h:101:32: note: previous definition of 'glutCreateMenuUcall_ATEXIT_HACK' with type 'int(void (*)(int,  void *), void *)'
  101 | static int FGAPIENTRY FGUNUSED glutCreateMenuUcall_ATEXIT_HACK(void(*func)(int, void*), void* user_data) { return __glutCreateMenuUcallWithExit(func, exit, user_data); }
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from c:\gcc1130\x86_64-w64-mingw32\include\gl\freeglut.h:17,
                 from gles_stubs.c:4:
gles_stubs.c:24:6: error: redefinition of 'glutCreateMenu_ATEXIT_HACK'
   24 | int  glutCreateMenu( void (* callback)( int menu ) ) { return 0; }
      |      ^~~~~~~~~~~~~~
c:\gcc1130\x86_64-w64-mingw32\include\gl\freeglut_std.h:641:32: note: previous definition of 'glutCreateMenu_ATEXIT_HACK' with type 'int(void (*)(int))'
  641 | static int FGAPIENTRY FGUNUSED glutCreateMenu_ATEXIT_HACK(void (* func)(int)) { return __glutCreateMenuWithExit(func, exit); }
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~
```