### PR TITLE
Remving WIN64 compiler warnings.

### DIFF
--- a/src/mswin/fg_main_mswin.c
+++ b/src/mswin/fg_main_mswin.c
@@ -44,8 +44,8 @@ extern void fgPlatformCheckMenuDeactivate(HWND newFocusWnd);
 #ifdef WM_TOUCH
 typedef BOOL (WINAPI *pGetTouchInputInfo)(HTOUCHINPUT,UINT,PTOUCHINPUT,int);
 typedef BOOL (WINAPI *pCloseTouchInputHandle)(HTOUCHINPUT);
-static pGetTouchInputInfo fghGetTouchInputInfo = (pGetTouchInputInfo)0xDEADBEEF;
-static pCloseTouchInputHandle fghCloseTouchInputHandle = (pCloseTouchInputHandle)0xDEADBEEF;
+static pGetTouchInputInfo fghGetTouchInputInfo = (pGetTouchInputInfo)((size_t)0xDEADBEEF);
+static pCloseTouchInputHandle fghCloseTouchInputHandle = (pCloseTouchInputHandle)((size_t)0xDEADBEEF);
 #endif
 
 #ifdef _WIN32_WCE
@@ -1507,7 +1507,7 @@ LRESULT CALLBACK fgPlatformWindowProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
         unsigned int i = 0;
         TOUCHINPUT* ti = (TOUCHINPUT*)malloc( sizeof(TOUCHINPUT)*numInputs);
 
-        if (fghGetTouchInputInfo == (pGetTouchInputInfo)0xDEADBEEF) {
+        if (fghGetTouchInputInfo == (pGetTouchInputInfo)((size_t)0xDEADBEEF)) {
             fghGetTouchInputInfo = (pGetTouchInputInfo)GetProcAddress(GetModuleHandle("user32"),"GetTouchInputInfo");
             fghCloseTouchInputHandle = (pCloseTouchInputHandle)GetProcAddress(GetModuleHandle("user32"),"CloseTouchInputHandle");
         }

--- a/src/mswin/fg_window_mswin.c
+++ b/src/mswin/fg_window_mswin.c
@@ -82,7 +82,7 @@ typedef HGLRC (WINAPI * PFNWGLCREATECONTEXTATTRIBSARBPROC) (HDC hDC, HGLRC hShar
 
 #ifdef WM_TOUCH
 typedef BOOL (WINAPI *pRegisterTouchWindow)(HWND,ULONG);
-static pRegisterTouchWindow fghRegisterTouchWindow = (pRegisterTouchWindow)0xDEADBEEF;
+static pRegisterTouchWindow fghRegisterTouchWindow = (pRegisterTouchWindow)((size_t)0xDEADBEEF);
 #endif
 
 
@@ -771,7 +771,7 @@ void fgPlatformOpenWindow( SFG_Window* window, const char* title,
 
     /* Enable multitouch: additional flag TWF_FINETOUCH, TWF_WANTPALM */
     #ifdef WM_TOUCH
-        if (fghRegisterTouchWindow == (pRegisterTouchWindow)0xDEADBEEF)
+        if (fghRegisterTouchWindow == (pRegisterTouchWindow)((size_t)0xDEADBEEF))
             fghRegisterTouchWindow = (pRegisterTouchWindow)GetProcAddress(GetModuleHandle("user32"),"RegisterTouchWindow");
         if (fghRegisterTouchWindow)
              fghRegisterTouchWindow( window->Window.Handle, TWF_FINETOUCH | TWF_WANTPALM );


### PR DESCRIPTION
These double casts remove warning `C4312 conversion from 'unsigned int' to '<>' of greater size`, which previously showed up when compiling on 64-bit windows.