### PR TITLE
Add support for ARM64 MSVC targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,7 +447,11 @@ IF(WIN32)
         # doesn't hurt for older compilers:
         # http://public.kitware.com/Bug/view.php?id=11240#c22768
         IF (CMAKE_CL_64)
-            SET_TARGET_PROPERTIES(freeglut_static PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
+            IF ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ARM64")
+                SET_TARGET_PROPERTIES(freeglut_static PROPERTIES STATIC_LIBRARY_FLAGS "/machine:ARM64")
+            ELSE()
+                SET_TARGET_PROPERTIES(freeglut_static PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
+            ENDIF()
         ENDIF()
     ENDIF()
 ELSE()


### PR DESCRIPTION
Currently, the CMakeLists.txt file assumes CL_64 == x64, which means static lib builds (such as in blender) are broken on ARM64 target platforms. This makes a check for this, which allows the build to succeed.