### PR TITLE
fghJoystickRawRead -> fgJoystickRawRead in solaris code

### DIFF
--- a/src/x11/fg_joystick_x11.c
+++ b/src/x11/fg_joystick_x11.c
@@ -627,7 +627,7 @@ void fgPlatformJoystickOpen( SFG_Joystick* joy )
 
     do
     {
-        fghJoystickRawRead( joy, NULL, joy->center );
+        fgJoystickRawRead( joy, NULL, joy->center );
         counter++;
     } while( !joy->error &&
              counter < 100 &&


### PR DESCRIPTION
fghJoystickRawRead changed name to fgJoystickRawRead but all uses of fghJoystickRawRead were not changed. This caused trouble on illumos/solaris when building and linking freeglut.
Fixes issue #149 .